### PR TITLE
add automatically_declare_parameters_from_overrides(true)

### DIFF
--- a/include/basalt_ros/vio_backend.hpp
+++ b/include/basalt_ros/vio_backend.hpp
@@ -65,7 +65,9 @@ class VIOBackEndNode : public rclcpp::Node
 {
 public:
   explicit VIOBackEndNode(const rclcpp::NodeOptions & options)
-  : Node("vio_backend", options)
+  : Node(
+      "vio_backend", rclcpp::NodeOptions(options)
+                       .automatically_declare_parameters_from_overrides(true))
   {
     backend_ = std::make_shared<VIOBackEnd>(this);
   }

--- a/include/basalt_ros/vio_frontend.hpp
+++ b/include/basalt_ros/vio_frontend.hpp
@@ -52,7 +52,9 @@ class VIOFrontEndNode : public rclcpp::Node
 {
 public:
   explicit VIOFrontEndNode(const rclcpp::NodeOptions & options)
-  : Node("vio_backend", options)
+  : Node(
+      "vio_frontend", rclcpp::NodeOptions(options)
+                        .automatically_declare_parameters_from_overrides(true))
   {
     frontend_ = std::make_shared<VIOFrontEnd>(this);
   }

--- a/src/viz_flow_node.cpp
+++ b/src/viz_flow_node.cpp
@@ -34,7 +34,9 @@ public:
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
 
   explicit VizFlow(const rclcpp::NodeOptions & options)
-  : Node("viz_flow", options)
+  : Node(
+      "viz_flow", rclcpp::NodeOptions(options)
+                    .automatically_declare_parameters_from_overrides(true))
 
   {
     sync_ = std::make_shared<Sync>(10);


### PR DESCRIPTION
This fixes a bug reported against the old repo here: https://github.com/berndpfrommer/basalt_ros2/issues/1
