### PR TITLE
revert back to declare_parameters

### DIFF
--- a/include/basalt_ros/vio_backend.hpp
+++ b/include/basalt_ros/vio_backend.hpp
@@ -65,9 +65,7 @@ class VIOBackEndNode : public rclcpp::Node
 {
 public:
   explicit VIOBackEndNode(const rclcpp::NodeOptions & options)
-  : Node(
-      "vio_backend", rclcpp::NodeOptions(options)
-                       .automatically_declare_parameters_from_overrides(true))
+  : Node("vio_backend", rclcpp::NodeOptions(options))
   {
     backend_ = std::make_shared<VIOBackEnd>(this);
   }

--- a/include/basalt_ros/vio_frontend.hpp
+++ b/include/basalt_ros/vio_frontend.hpp
@@ -52,9 +52,7 @@ class VIOFrontEndNode : public rclcpp::Node
 {
 public:
   explicit VIOFrontEndNode(const rclcpp::NodeOptions & options)
-  : Node(
-      "vio_frontend", rclcpp::NodeOptions(options)
-                        .automatically_declare_parameters_from_overrides(true))
+  : Node("vio_frontend", rclcpp::NodeOptions(options))
   {
     frontend_ = std::make_shared<VIOFrontEnd>(this);
   }

--- a/src/vio_publisher.cpp
+++ b/src/vio_publisher.cpp
@@ -76,10 +76,8 @@ VIOPublisher::VIOPublisher(rclcpp::Node * node) : node_(node)
           0.00, 0.00, 0.00, 0.01, 0.00, 0.00, 0.00, 0.00, 0.00,
           0.00, 0.01, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.01};
 
-  node_->get_parameter_or<std::string>(
-    "world_frame_id", msg_.header.frame_id, "world");
-  node_->get_parameter_or<std::string>(
-    "odom_frame_id", msg_.child_frame_id, "odom");
+  msg_.header.frame_id = node_->declare_parameter("world_frame_id", "world");
+  msg_.child_frame_id = node_->declare_parameter("odom_frame_id", "odom");
 
   std::vector<double> ext_trans = {0, 0, 0};
   std::vector<double> ext_q = {1.0, 0, 0, 0};

--- a/src/viz_flow_node.cpp
+++ b/src/viz_flow_node.cpp
@@ -34,9 +34,7 @@ public:
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
 
   explicit VizFlow(const rclcpp::NodeOptions & options)
-  : Node(
-      "viz_flow", rclcpp::NodeOptions(options)
-                    .automatically_declare_parameters_from_overrides(true))
+  : Node("viz_flow", rclcpp::NodeOptions(options))
 
   {
     sync_ = std::make_shared<Sync>(10);


### PR DESCRIPTION
automatically_declare_parameters_from_overrides() collides with declare_parameter(), so revert PR #1 
